### PR TITLE
Bug from issue 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ vendor
 *.test
 *.tmp
 draft/*
+
+tags
+

--- a/quick.go
+++ b/quick.go
@@ -326,15 +326,24 @@ func extractParamsGet(pathTmp, paramsPath string, handlerFunc func(*Ctx)) http.H
 func (q *Quick) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	for _, route := range q.routes {
 		var pathTmp string = req.URL.Path
-		routeParams := route.Params
 		var paramsMap = make(map[string]string)
+		var paramUriIndex = make([]int, 0)
 
 		if len(route.Pattern) > 0 && route.Method == req.Method {
-			routeParams = strings.Replace(routeParams, "/", "", -1)
-			tmppath := strings.Replace(req.URL.Path, route.Path, "", -1)
-			ppurl := strings.Split(tmppath, "/")[1:]
-			pathParams := strings.Split(routeParams, ":")[1:]
+			var routeParams string
+			ppurl := strings.Split(route.Pattern, "/")
+			paramsCount := 0
 
+			for i := 0; i < len(ppurl); i++ {
+				if strings.Contains(ppurl[i], ":") {
+					routeParams = routeParams + ppurl[i]
+					paramUriIndex = append(paramUriIndex, i)
+					paramsCount++
+				}
+			}
+
+			reqParams := strings.Split(pathTmp, "/")
+			pathParams := strings.Split(routeParams, ":")[1:]
 			prefix := ConcatStr(route.Path, "/")
 			if strings.HasPrefix(pathTmp, prefix) {
 				newPath := pathTmp[len(prefix):]
@@ -344,11 +353,12 @@ func (q *Quick) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 
 			if route.Path == pathTmp && route.Method == req.Method {
-				if len(pathParams) != len(ppurl) {
+				if len(pathParams) != paramsCount {
 					continue
 				}
+
 				for i, p := range pathParams {
-					paramsMap[p] = ppurl[i]
+					paramsMap[p] = reqParams[paramUriIndex[i]]
 				}
 
 				var c = ctxServeHttp{Path: pathTmp, ParamsMap: paramsMap, Method: route.Method}

--- a/quick_test.go
+++ b/quick_test.go
@@ -717,6 +717,7 @@ func BenchmarkPrintln_1000Bytes(b *testing.B) {
 	benchmarkPrintln(b, 1000)
 }
 
+// go test -v -count=1 -failfast -run ^Test_extractParamsPattern$
 func Test_extractParamsPattern(t *testing.T) {
 	type args struct {
 		pattern string
@@ -745,6 +746,15 @@ func Test_extractParamsPattern(t *testing.T) {
 			wantPath:          "/v1/customer/params",
 			wantParams:        "/:param1/:param2",
 			wantPartternExist: "/v1/customer/params/:param1/:param2",
+		},
+		{
+			name: "should ble able to extract 3 params",
+			args: args{
+				pattern: "/v1/customer/params/:param1/:param2/some/:param3",
+			},
+			wantPath:          "/v1/customer/params",
+			wantParams:        "/:param1/:param2/some/:param3",
+			wantPartternExist: "/v1/customer/params/:param1/:param2/some/:param3",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixing the bug that routes was not able to find value after some pattern like: /v1/api/:val/route1/:val2

![image](https://user-images.githubusercontent.com/43271729/221080065-07e6d52c-55d9-4856-bda7-179153465def.png)
![image](https://user-images.githubusercontent.com/43271729/221080220-b67c18d8-26d4-4d12-8502-e29b119e7508.png)
