### PR TITLE
Feat/register mw

### DIFF
--- a/quick.go
+++ b/quick.go
@@ -447,14 +447,9 @@ func (q *Quick) Static(staticFolder string) {
 }
 
 func (q *Quick) Listen(addr string) error {
-	var handler http.Handler = q
-	for i := len(q.mws) - 1; i >= 0; i-- {
-		handler = q.mws[i](handler)
-	}
-
 	server := &http.Server{
 		Addr:    addr,
-		Handler: handler,
+		Handler: q,
 		// ReadTimeout:
 		// WriteTimeout:
 		// MaxHeaderBytes:

--- a/quick.go
+++ b/quick.go
@@ -110,7 +110,7 @@ func (q *Quick) Post(pattern string, handlerFunc func(*Ctx)) {
 	}
 
 	q.routes = append(q.routes, route)
-	q.mux.HandleFunc(pathPost, route.handler)
+	q.registerHandler(pathPost, route.handler)
 }
 
 func extractHeaders(req http.Request) map[string][]string {
@@ -271,7 +271,7 @@ func (g *Group) Post(pattern string, handlerFunc func(*Ctx)) {
 	}
 
 	g.quick.routes = append(g.quick.routes, route)
-	g.quick.mux.HandleFunc(pathPost, route.handler)
+	g.quick.registerHandler(pathPost, route.handler)
 }
 
 func (q *Quick) Get(pattern string, handlerFunc func(*Ctx)) {
@@ -301,7 +301,7 @@ func (q *Quick) Put(pattern string, handlerFunc func(*Ctx)) {
 	}
 
 	q.routes = append(q.routes, route)
-	q.mux.HandleFunc(pathPut, route.handler)
+	q.registerHandler(pathPut, route.handler)
 }
 
 func extractParamsGet(pathTmp, paramsPath string, handlerFunc func(*Ctx)) http.HandlerFunc {

--- a/quick.go
+++ b/quick.go
@@ -216,6 +216,14 @@ func (c *Ctx) Param(key string) string {
 	return ""
 }
 
+func (q *Quick) registerHandler(pattern string, handler http.Handler) {
+	for i := range q.mws {
+		handler = q.mws[i](handler)
+	}
+
+	q.mux.Handle(pattern, handler)
+}
+
 func (c *Ctx) Body(v interface{}) (err error) {
 	if c.Request.Header.Get("Content-Type") == "application/json" {
 		if len(c.BodyByte) > 0 {
@@ -246,7 +254,7 @@ func (g *Group) Get(pattern string, handlerFunc func(*Ctx)) {
 	}
 
 	g.quick.routes = append(g.quick.routes, route)
-	g.quick.mux.HandleFunc(path, route.handler)
+	g.quick.registerHandler(path, route.handler)
 }
 
 func (g *Group) Post(pattern string, handlerFunc func(*Ctx)) {
@@ -277,7 +285,7 @@ func (q *Quick) Get(pattern string, handlerFunc func(*Ctx)) {
 	}
 
 	q.routes = append(q.routes, route)
-	q.mux.HandleFunc(path, route.handler)
+	q.registerHandler(path, route.handler)
 }
 
 func (q *Quick) Put(pattern string, handlerFunc func(*Ctx)) {


### PR DESCRIPTION
## Suporte a middlewares

Esse PR faz um wrap no handle das routes criando uma stack de middlewares para cada handler de cada route.

Exemplo:
```go
package main

import (
	"log"
	"net/http"

	"github.com/jeffotoni/quick"
)

func main() {
	app := quick.New()

	app.Use(func(h http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			//This is the first middleware! This guy generate a msgID
			r.Header.Set("Messageid", "12345")
			h.ServeHTTP(w, r)
		})
	})

	app.Get("/v1/customer/:param1/:param2", func(c *quick.Ctx) {
		c.Set("Content-Type", "application/json")

		type my struct {
			Msg string `json:"msg"`
			Key string `json:"key"`
			Val string `json:"val"`
		}

		log.Println(c.Headers["Messageid"])

		c.Status(200).Json(&my{
			Msg: "Quick ❤️",
			Key: c.Param("param1"),
			Val: c.Param("param2"),
		})
	})

	app.Use(func(h http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			//This is the third middleware! This guy blocks request if header contains Block == true
			if r.Header.Get("Block") == "" {
				w.WriteHeader(400)
				w.Write([]byte(`"Message": "send the block header, please! :("`))
				return
			}

			if r.Header.Get("Block") == "true" {
				w.WriteHeader(200)
				w.Write([]byte(`"Message": "quicks block this request :)"`))
				return
			}

			h.ServeHTTP(w, r)
		})
	})

	app.Get("/v1/blocked", func(c *quick.Ctx) {
		c.Set("Content-Type", "application/json")

		type my struct {
			Msg   string `json:"msg"`
			Block string `json:"block_message"`
		}

		log.Println(c.Headers["Messageid"])

		c.Status(200).Json(&my{
			Msg:   "Quick ❤️",
			Block: c.Headers["Block"][0],
		})
	})

	log.Fatal(app.Listen("0.0.0.0:8080"))
}

```
O middleware 1 eh global, enquanto o middleware 2 eh especifico para a segunda rota.

Exemplo: Passando Block = false, cai na rota 2
```bash
$ curl -iv -H "Block: false" localhost:8080/v1/blocked
*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /v1/blocked HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> Block: false
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Content-Type: application/json
Content-Type: application/json
< Date: Fri, 24 Feb 2023 13:58:13 GMT
Date: Fri, 24 Feb 2023 13:58:13 GMT
< Content-Length: 46
Content-Length: 46

< 
* Connection #0 to host localhost left intact
{"msg":"Quick ❤️","block_message":"false"}
```

Exemplo: Passando block = true, o middleware 2 bloqueia a request e retorna:
```bash
$ curl -iv -H "Block: true" localhost:8080/v1/blocked
*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /v1/blocked HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> Block: true
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Fri, 24 Feb 2023 13:58:53 GMT
Date: Fri, 24 Feb 2023 13:58:53 GMT
< Content-Length: 41
Content-Length: 41
< Content-Type: text/plain; charset=utf-8
Content-Type: text/plain; charset=utf-8

< 
* Connection #0 to host localhost left intact
"Message": "quicks block this request :)"
```

Exemplo: chamando rota 1 e passando block = true, deve chamar a rota 1 normalmente, pos o middleware 2 so server para a rota 2:
```bash
$ curl -iv -H "Block: true" localhost:8080/v1/customer/marco/polo     
*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /v1/customer/marco/polo HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> Block: true
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Content-Type: application/json
Content-Type: application/json
< Date: Fri, 24 Feb 2023 14:01:32 GMT
Date: Fri, 24 Feb 2023 14:01:32 GMT
< Content-Length: 49
Content-Length: 49

< 
* Connection #0 to host localhost left intact
{"msg":"Quick ❤️","key":"marco","val":"polo"}
```