### PR TITLE
refactor: remove unnecessary strings.HasSuffix checks

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -36,9 +36,8 @@ func (c *Ctx) GetHeadersAll() map[string][]string {
 // Http serveFile send specific file
 // The result will File(filePath string)
 func (c *Ctx) File(filePath string) error {
-	if strings.HasSuffix(filePath, "/*") {
-		filePath = strings.TrimSuffix(filePath, "/*")
-	}
+	filePath = strings.TrimSuffix(filePath, "/*")
+
 	if stat, err := os.Stat(filePath); err == nil && stat.IsDir() {
 		filePath = filepath.Join(filePath, "index.html")
 	}

--- a/quick.go
+++ b/quick.go
@@ -505,9 +505,7 @@ func (q *Quick) GetRoute() []*Route {
 // are embedded into the executable.
 // The result will Static(route string, dirOrFS any)
 func (q *Quick) Static(route string, dirOrFS any) {
-	if strings.HasSuffix(route, "/") {
-		route = strings.TrimSuffix(route, "/")
-	}
+	route = strings.TrimSuffix(route, "/")
 
 	var fileServer http.Handler
 


### PR DESCRIPTION
This PR removes redundant `strings.HasSuffix` checks. 
As per the documentation for `strings.TrimSuffix`:

```go
func strings.TrimSuffix(s string, suffix string) string
```
[TrimSuffix](https://pkg.go.dev/strings#TrimSuffix) returns s without the provided trailing suffix string. If s doesn't end with the suffix, s is returned unchanged.

Thus, there is no need to check for the suffix before calling `strings.TrimSuffix`, as it handles the case when the suffix is not present.