### PR TITLE
feat: remove x-powered-by and server header

### DIFF
--- a/example/middleware/helmet/custom/main.go
+++ b/example/middleware/helmet/custom/main.go
@@ -14,6 +14,7 @@ func main() {
 		CSPReportOnly:         true,
 		HSTSMaxAge:            86400,
 		HSTSExcludeSubdomains: true,
+		HidePoweredBy:         true,
 		PermissionsPolicy:     "geolocation=(), microphone=()",
 		Next: func(c *quick.Ctx) bool {
 			return c.Path() == "/public"

--- a/middleware/helmet/helmet.go
+++ b/middleware/helmet/helmet.go
@@ -60,6 +60,15 @@ type Options struct {
 
 	// CacheControl sets Cache-Control header
 	CacheControl string
+
+	// HidePoweredBy sets the X-Powered-By header
+	HidePoweredBy bool
+
+	// PoweredBy sets the X-Powered-By header
+	PoweredBy string
+
+	// ServerHeader sets the Server header
+	ServerHeader string
 }
 
 // Helmet returns a Quick-compatible middleware that adds security headers to the response
@@ -145,6 +154,22 @@ func Helmet(opt ...Options) func(next quick.Handler) quick.Handler {
 				c.Set("Cache-Control", options.CacheControl)
 			}
 
+			// remove X-Powered-By and Server headers
+			if options.HidePoweredBy {
+				c.Del("X-Powered-By")
+				c.Del("Server")
+			}
+
+			// X-Powered-By
+			if options.PoweredBy != "" {
+				c.Set("X-Powered-By", options.PoweredBy)
+			}
+
+			// Server
+			if options.ServerHeader != "" {
+				c.Set("Server", options.ServerHeader)
+			}
+
 			return next.ServeQuick(c)
 		})
 	}
@@ -170,6 +195,9 @@ func defaultOptions() Options {
 		HSTSMaxAge:                31536000,
 		HSTSPreloadEnabled:        true,
 		CacheControl:              "no-cache, no-store, must-revalidate",
+		HidePoweredBy:             true,
+		PoweredBy:                 "",
+		ServerHeader:              "",
 	}
 }
 

--- a/middleware/helmet/helmet_test.go
+++ b/middleware/helmet/helmet_test.go
@@ -44,6 +44,8 @@ func TestHelmet(t *testing.T) {
 	resp.AssertHeader("X-DNS-Prefetch-Control", "off")
 	resp.AssertHeader("X-Download-Options", "noopen")
 	resp.AssertHeader("X-Permitted-Cross-Domain-Policies", "none")
+	resp.AssertHeader("X-Powered-By", "")
+	resp.AssertHeader("Server", "")
 }
 
 // TestHelmetWithoutMiddleware confirms that no security headers are set when Helmet is not used.
@@ -144,4 +146,27 @@ func TestHelmetWithNextFunc(t *testing.T) {
 
 	resp.AssertNoHeader("Content-Security-Policy")
 	resp.AssertString("skipped")
+}
+
+// TestHelmetWithHidePoweredBy ensures that X-Powered-By and Server headers are hidden.
+func TestHelmetWithHidePoweredBy(t *testing.T) {
+	q := quick.New()
+	q.Use(Helmet(Options{
+		HidePoweredBy: true,
+	}))
+
+	q.Get("/", func(c *quick.Ctx) error {
+		return c.String("ok")
+	})
+
+	resp, err := q.Qtest(quick.QuickTestOptions{
+		Method: quick.MethodGet,
+		URI:    "/",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	resp.AssertNoHeader("X-Powered-By")
+	resp.AssertNoHeader("Server")
 }


### PR DESCRIPTION
hello @jeffotoni this is the PR which remove `x-powered-by` and `server` headers