### PR TITLE
chore: cleaned path to handle response

### DIFF
--- a/quick.go
+++ b/quick.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/signal"
+	"path"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -1356,7 +1357,7 @@ func (q *Quick) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer releaseCtx(ctx)     // Returns it to the pool
 
 	for i := range q.routes {
-		var requestURI = req.URL.Path
+		var requestURI = path.Clean(req.URL.Path)
 		var patternUri = q.routes[i].Pattern
 
 		if q.routes[i].Method != req.Method {
@@ -1364,7 +1365,7 @@ func (q *Quick) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if len(patternUri) == 0 {
-			patternUri = q.routes[i].Path
+			patternUri = path.Clean(q.routes[i].Path)
 		}
 
 		paramsMap, isValid := createParamsAndValid(requestURI, patternUri)

--- a/quick.go
+++ b/quick.go
@@ -1365,10 +1365,10 @@ func (q *Quick) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if len(patternUri) == 0 {
-			patternUri = path.Clean(q.routes[i].Path)
+			patternUri = q.routes[i].Path
 		}
 
-		paramsMap, isValid := createParamsAndValid(requestURI, patternUri)
+		paramsMap, isValid := createParamsAndValid(requestURI, path.Clean(patternUri))
 
 		if !isValid {
 			continue // This route doesn't match, continue checking.


### PR DESCRIPTION
hello @jeffotoni i hope you good today.
i have make a small improvement for in the Quick route handler.

The goal of this PR is to clean the given path from users.

for example an user can create app below:
```go
package main

import (
	"errors"

	"github.com/jeffotoni/quick"
	"github.com/jeffotoni/quick/middleware/recover"
)

func main() {
	q := quick.New()

	// Apply the Recover middleware
	q.Use(recover.New())

	// Define a test route
	q.Get("/v1//user", func(c *quick.Ctx) error {
          return c.Status(200).String("John Doe")
	})

	// Start the server
	q.Listen("0.0.0.0:8080")
}
```
we can see the route is `/v1//user` and is not cleaned and not good for user experience.

that's why in this PR, we cleaned all path before to handle. that means `/v1//user` become `/v1/user` and the both url are accessible. 

What do you think ?

Or maybe we can send a message about the not cleaned URL? 
